### PR TITLE
Fix Wine installation

### DIFF
--- a/src/pkg/Installer.cpp
+++ b/src/pkg/Installer.cpp
@@ -2,6 +2,7 @@
 #include <stdexcept>
 #include <memory>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <fcntl.h>
 #include <iostream>
 #include <cstring>
@@ -138,6 +139,36 @@ std::string Installer::getInstallLocation()
 	return path;
 }
 
+void Installer::mkParentDirs(const char *fileName, mode_t mode)
+{
+	// Create directories so that it's possible to create the specified file,
+	// in a manner similiar to `mkdir -p`
+
+	char *path = strdup(fileName);
+
+	for (char *pos = path; pos != nullptr; pos = strchr(pos + 1, '/'))
+	{
+		if (pos == path)
+			continue;
+
+		*pos = '\0';
+
+		if (::mkdir(path, mode) != 0)
+		{
+			if (errno != EEXIST)
+			{
+				std::stringstream ss;
+				ss << "Cannot mkdir " << path << ": " << strerror(errno);
+				throw std::runtime_error(ss.str());
+			}
+		}
+
+		*pos = '/';
+	}
+
+	free(path);
+}
+
 void Installer::extractPayload(const char* payloadFileName, std::string destinationDir)
 {
 	std::string path, name;
@@ -170,7 +201,9 @@ void Installer::extractPayload(const char* payloadFileName, std::string destinat
 		path += name;
 		
 		// std::cout << path << std::endl;
-		
+
+		mkParentDirs(path.c_str(), st.st_mode & 0777);
+
 		if (S_ISDIR(st.st_mode))
 		{
 			if (::mkdir(path.c_str(), st.st_mode & 0777) != 0)

--- a/src/pkg/Installer.cpp
+++ b/src/pkg/Installer.cpp
@@ -288,7 +288,8 @@ int Installer::installPayload(const char* subdir)
 	char scriptsDir[] = "/tmp/installerXXXXXX";
 	ReceiptsDb::InstalledPackageInfo installedPackageInfo;
 	bool isUpgrade = false;
-	
+	Reader *bomReader;
+
 	m_subdir = subdir;
 	
 	m_pkgInfo = loadPackageInfo();
@@ -359,8 +360,13 @@ int Installer::installPayload(const char* subdir)
 	
 	// Copy BOM file
 	bomPath = ReceiptsDb::getInstalledPackageBOMPath(identifier.c_str());
-	extractFile(std::shared_ptr<Reader>(m_xar->openFile(getSubdirFilePath("Bom"))), bomPath.c_str());
-	
+	bomReader = m_xar->openFile(getSubdirFilePath("Bom"));
+	if (bomReader == nullptr)
+		bomReader = m_xar->openFile(getSubdirFilePath("BOM"));
+	if (bomReader == nullptr)
+		throw std::runtime_error("Cannot find bom file");
+	extractFile(std::shared_ptr<Reader>(bomReader), bomPath.c_str());
+
 	return 0;
 }
 

--- a/src/pkg/Installer.h
+++ b/src/pkg/Installer.h
@@ -2,6 +2,7 @@
 #define INSTALLER_H
 #include <memory>
 #include <string>
+#include <sys/types.h>
 #include "archive/XARArchive.h"
 #include "PackageInfoXml.h"
 #include "bom/BOMStore.h"
@@ -14,6 +15,7 @@ public:
 	void installPackage();
 private:
 	std::shared_ptr<PackageInfoXml> loadPackageInfo();
+	void mkParentDirs(const char *fileName, mode_t mode);
 	void extractPayload(const char* payloadFileName, std::string destinationDir);
 	int installPayload(const char* subdir = "");
 	std::string getSubdirFilePath(const char* fileName);


### PR DESCRIPTION
I'm trying to install Wine (https://dl.winehq.org/wine-builds/macosx/i686/winehq-staging-2.0-rc4.pkg; doesn't run yet). The package is a bit unusual (that is, different from those of Rudix), but installs fine on macOS, whereas it fails to install on Darling:

* Unlike packages from Rudix (and most others, I assume) that contain the full "folder path" (`/`, `/usr`, `/usr/local`, `/usr/local/bin`), Wine starts directly at `/Applications/Wine Staging.app/Contents`, and Darling installer fails with `ENOENT`.
    * Fix: do smth like `mkdir -p $(dirname $file)` before unpacking each file.
* They use `whatever/BOM` instead of `whatever/Bom`. This may have something to do with case-insensitive file systems (do they emulate a case-insensitive XAR?). Darling installer segfaults on not finding the file, getting a `nullptr` for reader and attempting to use it.
    * Quick fix: if `/Bom` is not found, look for `/BOM`; if it's not found too -- throw an error.
    * A proper fix would be to make XAR code case-insensitive (if it should be).

With these two fixes, Wine installs successfully.