### PR TITLE
Make XAR reader case-insensitive

### DIFF
--- a/src/archive/XARArchive.cpp
+++ b/src/archive/XARArchive.cpp
@@ -7,6 +7,8 @@
 #include "be.h"
 #include <iostream>
 #include <sstream>
+#include <algorithm>
+#include <string>
 #include "ArchivedFileReader.h"
 
 XARArchive::XARArchive(std::shared_ptr<Reader> reader)
@@ -65,10 +67,15 @@ std::string XARArchive::xpathForPath(const std::string& path)
 
 	ss << "/xar/toc";
 
-	for (const std::string& p : parts)
+	for (std::string p : parts)
 	{
-		if (!p.empty())
-			ss << "/file[name='" << p << "']"; // TODO: escape file name
+		if (p.empty())
+			continue;
+
+		// libxml2 only supports XPath 1.0
+		std::transform(p.begin(), p.end(), p.begin(), ::tolower);
+		// TODO: escape file name
+		ss << "/file[translate(name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')='" << p << "']";
 	}
 	ss << "/data";
 	

--- a/src/pkg/Installer.cpp
+++ b/src/pkg/Installer.cpp
@@ -395,8 +395,6 @@ int Installer::installPayload(const char* subdir)
 	bomPath = ReceiptsDb::getInstalledPackageBOMPath(identifier.c_str());
 	bomReader = m_xar->openFile(getSubdirFilePath("Bom"));
 	if (bomReader == nullptr)
-		bomReader = m_xar->openFile(getSubdirFilePath("BOM"));
-	if (bomReader == nullptr)
 		throw std::runtime_error("Cannot find bom file");
 	extractFile(std::shared_ptr<Reader>(bomReader), bomPath.c_str());
 


### PR DESCRIPTION
> yes, we should make the XAR reader case-insensitive. Can you take a look at that?

:white_check_mark: Done

Unfortunately, libxml2 only supports XPath 1.0, so we have to resort to hacks like `translate(name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'` that look bad & only work for ASCII.