### PR TITLE
Support pkg without title in choice-tags.

### DIFF
--- a/src/pkg/DistributionXml.cpp
+++ b/src/pkg/DistributionXml.cpp
@@ -58,8 +58,7 @@ std::vector<DistributionXml::Choice> DistributionXml::choices() const
 			continue;
 
 		attrVal = xmlGetProp(node, (xmlChar*) "title");
-		if (!attrVal) throw std::runtime_error("Element <choice> lacks 'title' attributte");
-		choice.title = (char*) attrVal;
+		if (attrVal) choice.title = (char*) attrVal;
 
 		attrVal = xmlGetProp(node, (xmlChar*) "id");
 		if (!attrVal) throw std::runtime_error("Element <choice> lacks 'id' attributte");

--- a/src/pkg/Installer.cpp
+++ b/src/pkg/Installer.cpp
@@ -71,7 +71,12 @@ void Installer::installPackage()
 			if (!c.selected)
 				continue;
 			
-			std::cout << "installer: Installing selected choice " << c.title << std::endl;
+			std::string choiceTitle = c.title;
+			// Fallback to using id as a replacement for title
+			if (choiceTitle.empty())
+				choiceTitle = c.id;
+			
+			std::cout << "installer: Installing selected choice " << choiceTitle << std::endl;
 			
 			for (const std::string& pkgId : c.pkgref)
 			{


### PR DESCRIPTION
Make the title attribute in the choice tag optional and fallback to the id attribute if title is not available.
Fixes https://github.com/darlinghq/darling/issues/366.