### PR TITLE
fix wrong capture pkg.path behavior when Distribution xml contain

### DIFF
--- a/src/pkg/DistributionXml.cpp
+++ b/src/pkg/DistributionXml.cpp
@@ -126,7 +126,7 @@ bool DistributionXml::package(const std::string& id, DistributionXml::PkgRef& pk
 		if (attrVal != nullptr)
 			pkg.installKbytes = atoi((char*) attrVal);
 
-		if (pkg.path.empty() && node->children && node->children->type == XML_TEXT_NODE)
+		if (pkg.path.empty() && node->children && node->children->type == XML_TEXT_NODE && !xmlIsBlankNode(node->children))
 			pkg.path = (char*) node->children->content;
 	}
 	


### PR DESCRIPTION
Hello.

Fix wrong capture pkg.path behavior when Distribution xml contain whitespace..

Without that changes installer can't install some packages.

For example node package from [https://nodejs.org/en/download/](https://nodejs.org/en/download/)

Best Regards, Ilya Pavlov