### PR TITLE
Decode space character from URL encoding to ASCII

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ add_darling_executable(installer
 	src/bom/BOMStore.cpp
 	src/bom/BOMBTree.cpp
 	src/bom/BOMFilesBTree.cpp
-	src/pkg/DistributionXml.cpp
+	src/pkg/DistributionXml.mm
 	src/pkg/PackageInfoXml.cpp
 	src/pkg/ReceiptsDb.cpp
 	src/pkg/Installer.cpp
@@ -41,7 +41,7 @@ add_darling_executable(installer
 	src/main-pkgutil.cpp
 )
 
-target_link_libraries(installer z lzma bz2 xml2 cxx CoreFoundation)
+target_link_libraries(installer z lzma bz2 xml2 cxx CoreFoundation Foundation)
 install(TARGETS installer RUNTIME DESTINATION libexec/darling/usr/bin)
 
 set(BINARY_PACKAGING_MODE ON)
@@ -50,4 +50,3 @@ InstallSymlink(installer libexec/darling/usr/bin/pkgutil)
 InstallSymlink(installer libexec/darling/usr/bin/lsbom)
 
 install(FILES installer.8 DESTINATION libexec/darling/usr/share/man/man8)
-

--- a/src/pkg/DistributionXml.mm
+++ b/src/pkg/DistributionXml.mm
@@ -1,6 +1,7 @@
 #include "DistributionXml.h"
 #include <stdexcept>
 #include <cstring>
+#import <Foundation/Foundation.h>
 
 DistributionXml::DistributionXml(std::shared_ptr<Reader> file)
 {
@@ -128,9 +129,11 @@ bool DistributionXml::package(const std::string& id, DistributionXml::PkgRef& pk
 
 		if (pkg.path.empty() && node->children && node->children->type == XML_TEXT_NODE && !xmlIsBlankNode(node->children))
 			pkg.path = (char*) node->children->content;
+
+		NSString *nsPath = [NSString stringWithUTF8String: pkg.path.c_str()];
+		pkg.path = [[nsPath stringByRemovingPercentEncoding] cStringUsingEncoding: NSUTF8StringEncoding];
 	}
-	
+
 	xmlXPathFreeObject(xpathObj);
 	return true;
 }
-


### PR DESCRIPTION
With that AudioFuse Control Center can be installed (there are other changes needed to make it work, but is in progress currently)

Closes [darling#1625](https://github.com/darlinghq/darling/issues/1625)